### PR TITLE
postfix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.py[oc]
 # Created by .ignore support plugin (hsz.mobi)
 
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ run_tls: build_tls
 run_imap: build_imap
 	docker run -p 25:25 -p 143:10143 -e MYHOSTNAME=localhost $(IMAGE_NAME_IMAP)
 
-test:
-	run_test.sh
+test: build
+	cd tests; MODULE=docker MODULEMD=$(MODULEMDURL) URL="docker=$(IMAGE_NAME)" make all

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,6 @@
+MODULE_LINT=/usr/share/moduleframework/tools/modulelint.py
+CMD=python -m avocado run --filter-by-tags=-WIP $(MODULE_LINT) *.py
+
+#
+all:
+	$(CMD)

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,0 +1,21 @@
+document: modularity-testing
+version: 1
+name: postfix
+modulemd-url: http://raw.githubusercontent.com/container-images/postfix/master/postfix.yaml
+service:
+    port: 25
+packages:
+    rpms:
+        - postfix
+testdependecies:
+    rpms:
+        - nc
+module:
+    docker:
+        start: "docker run -e MYHOSTNAME=localhost -p 25:10025"
+        source: https://github.com/container-images/postfix.git
+        container: docker.io/modularitycontainers/postfix
+    rpm:
+        start: systemctl start postfix
+        stop: systemctl stop postfix
+        status: systemctl status postfix

--- a/tests/sanity1.py
+++ b/tests/sanity1.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This Modularity Testing Framework helps you to write tests for modules
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Jan Scotka <jscotka@redhat.com>
+#
+
+import socket
+from avocado import main
+from avocado.core import exceptions
+from moduleframework import module_framework
+
+
+class SanityCheck1(module_framework.AvocadoTest):
+    """
+    :avocado: enable
+    """
+
+    def testConnectToPostfix(self):
+        self.start()
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect(('localhost', self.getConfig()['service']['port']))
+        s.sendall("HELO test.localhost")
+        s.close()
+
+    def testPostfixExists(self):
+        self.start()
+        self.run("ls -la /usr/sbin/postfix")
+
+    def testPostfixConfiguration(self):
+        self.start()
+        self.run("postconf -n mydomain | grep localhost")
+        self.run("postconf -n myhostname | grep mail.localhost")
+        self.run("postconf -n mydestination | grep localhost")
+
+    def testPostfixSkipped(self):
+        module_framework.skipTestIf("postfix" not in self.getActualProfile())
+        self.start()
+        self.run("postconf -n")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

I have added first set of tests for postfix.
Tests which failed are caused by MTF.
~~~
$ sudo make test
docker build --tag=postfix .
Sending build context to Docker daemon 604.2 kB
Step 1 : FROM modularitycontainers/boltron-preview:latest
 ---> 8e9b6d59152c
Step 2 : ENV POSTFIX_SMTP_PORT 10025 NAME postfix ARCH x86_64
 ---> Using cache
 ---> 4ca0098825e2
Step 3 : LABEL MAINTAINER "Petr Hracek" <phracek@redhat.com>
 ---> Using cache
 ---> 6d2c52557362
Step 4 : LABEL summary "Postfix is a Mail Transport Agent (MTA)." name "$FGC/$NAME" version "0" release "1.$DISTTAG" architecture "$ARCH" com.redhat.component "$NAME" usage "docker run -it -e MYHOSTNAME=localhost -p 25:10025 -v $(pwd)/tmp/postfix:/var/spool/postfix -v $(pwd)/tmp/mail:/var/spool/mail postfix" help "Runs postfix, which listens on port 25. No dependencies. See Help File belowe for more detailes." description "Postfix is mail transfer agent that routes and delivers mail." io.k8s.description "Postfix is mail transfer agent that routes and delivers mail." io.k8s.diplay-name "Postfix 3.1" io.openshift.expose-services "10025:postfix" io.openshift.tags "postfix,mail,mta"
 ---> Using cache
 ---> 3fa735867ec6
Step 5 : RUN dnf install -y --rpm --nodocs findutils &&     dnf install -y --nodocs postfix &&     dnf -y clean all
 ---> Using cache
 ---> 11a8929b94be
Step 6 : ADD files /files
 ---> Using cache
 ---> 1a399dccf535
Step 7 : ADD README.md /
 ---> Using cache
 ---> 6838e3767ca8
Step 8 : RUN /files/postfix_config.sh
 ---> Using cache
 ---> 98ba6b6c334f
Step 9 : EXPOSE 10025
 ---> Using cache
 ---> 262e39d1cadb
Step 10 : VOLUME ['/var/spool/postfix']
 ---> Using cache
 ---> e7b9a74ffe83
Step 11 : VOLUME ['/var/spool/mail']
 ---> Using cache
 ---> 1fca5a31f187
Step 12 : CMD /files/start.sh
 ---> Using cache
 ---> 0396500d0957
Successfully built 0396500d0957
cd tests; MODULE=docker MODULEMD= URL="docker=postfix" make all
make[1]: Entering directory '/home/phracek/work/container-images/postfix/tests'
python -m avocado run --filter-by-tags=-WIP /usr/share/moduleframework/tools/modulelint.py *.py
JOB ID     : 107e770536901527df4959ba131d31f164b47404
JOB LOG    : /root/avocado/job-results/job-2017-08-01T11.55-107e770/job.log
 (01/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testDockerFromBaseruntime: FAIL (0.03 s)
 (02/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testDockerNodocs: PASS (35.10 s)
 (03/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testDockerCleanAll: FAIL (22.63 s)
 (04/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testArchitectureInEnvAndLabelExists: PASS (0.02 s)
 (05/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testNameInEnvAndLabelExists: PASS (0.01 s)
 (06/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testReleaseLabelExists: PASS (0.02 s)
 (07/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testVersionLabelExists: PASS (0.02 s)
 (08/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testComRedHatComponentLabelExists: PASS (0.01 s)
 (09/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testIok8sDescriptionExists: PASS (0.02 s)
 (10/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testIoOpenshiftExposeServicesExists: PASS (0.02 s)
 (11/19) /usr/share/moduleframework/tools/modulelint.py:DockerfileLinter.testIoOpenShiftTagsExists: PASS (0.01 s)
 (12/19) /usr/share/moduleframework/tools/modulelint.py:DockerLint.testBasic: PASS (23.92 s)
 (13/19) /usr/share/moduleframework/tools/modulelint.py:DockerLint.testContainerIsRunning: PASS (24.11 s)
 (14/19) /usr/share/moduleframework/tools/modulelint.py:DockerLint.testLabels: CANCEL (1.80 s)
 (15/19) /usr/share/moduleframework/tools/modulelint.py:ModuleLintPackagesCheck.test: PASS (24.26 s)
 (16/19) sanity1.py:SanityCheck1.testConnectToPostfix: PASS (23.86 s)
 (17/19) sanity1.py:SanityCheck1.testPostfixExists: PASS (24.07 s)
 (18/19) sanity1.py:SanityCheck1.testPostfixConfiguration: PASS (23.83 s)
 (19/19) sanity1.py:SanityCheck1.testPostfixSkipped: PASS (24.43 s)
RESULTS    : PASS 16 | ERROR 0 | FAIL 2 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 231.54 s
JOB HTML   : /root/avocado/job-results/job-2017-08-01T11.55-107e770/results.html
Makefile:6: recipe for target 'all' failed
make[1]: *** [all] Error 1
make[1]: Leaving directory '/home/phracek/work/container-images/postfix/tests'
Makefile:33: recipe for target 'test' failed
make: *** [test] Error 2
$ 

~~~